### PR TITLE
Added Registry Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Fix for accessing administrative rules
 - Get information about the system
 - System file checker
+- Registry Checker
 #
 
 # How to use?


### PR DESCRIPTION
Checks the registry for values left by IDA that could cause bans in games where the anti cheat checks the registry like call of duty's ricochet ac. Credits to nicholasbroo on UC for pointing out which keys are being checked by the ac. In the future, there could be more values added from other areas of the registry. Maybe add other IDA keys to check for later (example: SOFTWARE\Hex-Rays\IDA\History\$, ...) Code is tested to some extend, should be stable.